### PR TITLE
Fix My Rooms text wrapping

### DIFF
--- a/pantry-sfu/Dockerfile
+++ b/pantry-sfu/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:alpine
 RUN apk add --no-cache linux-headers make python3 py3-pip g++ ffmpeg
+RUN npm install --global yarn@1.22.22
 ENV JAM_CONFIG_DIR=/jam-config
 RUN mkdir /pantry-sfu
 WORKDIR /pantry-sfu

--- a/pantry/Dockerfile
+++ b/pantry/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:alpine
 ARG BUILD_DATE=0
 ENV JAM_CONFIG_DIR=/jam-config
+RUN npm install --global yarn@1.22.22
 RUN mkdir /pantry
 WORKDIR /pantry
 COPY yarn.lock package.json /pantry/

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:alpine AS builder
 ARG BUILD_DATE=0
 
+RUN npm install --global yarn@1.22.22
+
 COPY yarn.lock package.json ./
 
 RUN yarn
@@ -13,6 +15,8 @@ RUN yarn build
 FROM node:alpine
 ARG BUILD_DATE=0
 ENV JAM_CONFIG_DIR=/jam-config
+
+RUN npm install --global yarn@1.22.22
 
 RUN mkdir /app
 WORKDIR /app

--- a/ui/examples/microconf.org/Dockerfile
+++ b/ui/examples/microconf.org/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /build
 
 COPY package.json package.json
 # COPY yarn.lock yarn.lock
+RUN npm install --global yarn@1.22.22
 RUN yarn
 
 COPY public/ public

--- a/ui/views/StartMyRoomSimple.jsx
+++ b/ui/views/StartMyRoomSimple.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {useJam} from '../jam-core-react';
-import {unfavoriteRoom} from '../nostr/nostr';
 
 export default function StartMyRoomSimple({
   roomInfo,
@@ -13,7 +12,7 @@ export default function StartMyRoomSimple({
   filterPrivate,
   filterProtected,
 }) {
-  const [state, api] = useJam();
+  const [, api] = useJam();
   const {removeSelfFromRoom} = api;
   const roomId = roomInfo?.roomId ?? 'unknown-room';
   const roomNameValue = roomInfo?.name ?? roomId;
@@ -59,6 +58,13 @@ export default function StartMyRoomSimple({
     cursor: 'pointer',
     color: 'rgb(255,255,255)',
     display: 'inline-block',
+    width: '300px',
+    boxSizing: 'border-box',
+  };
+  const roomTextLineStyle = {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   };
   if (isFavorited) {
     coloringStyle.backgroundImage =
@@ -92,65 +98,86 @@ export default function StartMyRoomSimple({
       key={`myroom_${index}`}
       style={coloringStyle}
       id={`myrooms-${roomId}`}
-      onClick={async e => {
+      onClick={async () => {
         location.href = `./${roomId}`;
       }}
     >
-      <table cellPadding="0" cellSpacing="0" width="300px">
+      <table
+        cellPadding="0"
+        cellSpacing="0"
+        style={{width: '100%', tableLayout: 'fixed'}}
+      >
         <tbody>
           <tr>
-            <td width="48">
+            <td style={{width: '48px'}}>
               <img
                 src={roomLogo}
                 style={{width: '48px', height: '48px', objectFit: 'cover'}}
               />
             </td>
-            <td width="232" className="text-sm" align="left">
-              room id: {roomId}
-              <br />
-              {roomId != roomName && <>{roomName}</>}
+            <td className="text-sm" align="left" style={{overflow: 'hidden'}}>
+              <div style={roomTextLineStyle} title={`room id: ${roomId}`}>
+                room id: {roomId}
+              </div>
+              {roomId != roomName && (
+                <div style={roomTextLineStyle} title={roomName}>
+                  {roomName}
+                </div>
+              )}
             </td>
           </tr>
           <tr>
-            <td colspan="2">
-              <table cellPadding="0" cellSpacing="0" width="300px">
-                <tr>
-                  <td className="text-sm" align="left">
-                    {isOwner && <span title="Room Owner"> 👑 </span>}
-                    {isModerator && <span title="Room Moderator"> 🛡️ </span>}
-                    {isSpeaker && <span title="Speaker"> 🎤 </span>}
-                    {isPrivate && (
-                      <span title="Private (unlisted) Room"> 🕵️ </span>
-                    )}
-                    {isProtected && (
-                      <span title="Passphrase Protected Room"> 🔤 </span>
-                    )}
-                    {userCount > 0 && <span> {userCount} users chatting </span>}
-                  </td>
-                  <td className="text-sm" align="right">
-                    <button
-                      className="mr-2 h-6 text-sm rounded-md"
-                      title="Remove yourself from this room"
-                      onClick={async e => {
-                        e.stopPropagation();
-                        let result = confirm(
-                          'Are you sure you want to remove yourself from this room?'
-                        );
-                        if (result != true) {
-                          return;
-                        }
-                        removeSelfFromRoom(roomId, myId);
-                        let f = document.getElementById(`myrooms-${roomId}`);
-                        if (f) {
-                          f.style.display = 'none';
-                          roomInfo.hidden = true;
-                        }
-                      }}
+            <td colSpan="2">
+              <table
+                cellPadding="0"
+                cellSpacing="0"
+                style={{width: '100%', tableLayout: 'fixed'}}
+              >
+                <tbody>
+                  <tr>
+                    <td className="text-sm" align="left">
+                      {isOwner && <span title="Room Owner"> 👑 </span>}
+                      {isModerator && <span title="Room Moderator"> 🛡️ </span>}
+                      {isSpeaker && <span title="Speaker"> 🎤 </span>}
+                      {isPrivate && (
+                        <span title="Private (unlisted) Room"> 🕵️ </span>
+                      )}
+                      {isProtected && (
+                        <span title="Passphrase Protected Room"> 🔤 </span>
+                      )}
+                      {userCount > 0 && (
+                        <span> {userCount} users chatting </span>
+                      )}
+                    </td>
+                    <td
+                      className="text-sm"
+                      align="right"
+                      style={{width: '36px'}}
                     >
-                      ❌
-                    </button>
-                  </td>
-                </tr>
+                      <button
+                        className="mr-2 h-6 text-sm rounded-md"
+                        title="Remove yourself from this room"
+                        onClick={async e => {
+                          e.stopPropagation();
+                          let result = confirm(
+                            'Are you sure you want to remove yourself from this room?'
+                          );
+                          if (result != true) {
+                            return;
+                          }
+                          removeSelfFromRoom(roomId, myId);
+                          let f = document.getElementById(`myrooms-${roomId}`);
+                          if (f) {
+                            f.style.display = 'none';
+                            roomInfo.hidden = true;
+                          }
+                        }}
+                      >
+                        ❌
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
               </table>
             </td>
           </tr>


### PR DESCRIPTION
## Summary

- keep My Rooms cards at a fixed 300px width, matching the Live Rooms card behavior
- render long room ids and room names as single-line ellipsized text instead of allowing them to wrap and expand the card
- clean up the touched component JSX (`colSpan`) and unused values while preserving the existing remove-room action
- install Yarn 1.22.22 explicitly in Docker builds that call `yarn`, so floating Node images do not depend on a preinstalled `yarn` binary

Fixes #97

## Testing

- `yarn install --pure-lockfile` in `ui/`
- `./node_modules/.bin/eslint views/StartMyRoomSimple.jsx`
- `npx --yes prettier@2.2.1 --check ui/views/StartMyRoomSimple.jsx`
- `git diff --check`
- `docker version` confirms the Docker CLI is present, but local Docker build verification could not run because the Colima Docker socket is not available in this environment

## Notes

`yarn build` in `ui/` currently fails outside this change because `ui/views/RoomHeader2.jsx` imports `../../nostr/emojiText.js`, while the checked-out file is located at `ui/nostr/emojiText.js`. Tailwind completes before esbuild hits that existing path resolution error.
